### PR TITLE
Refactor cursor management and revised function locations under text_mod

### DIFF
--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -16,7 +16,7 @@ use interrupts::pic::init_pic;
 use interrupts::utils::enable_interrupts;
 use vga::text_mod::out::{init_virtual_screens, print};
 
-use crate::vga::text_mod::cursor::{set_big_cursor, set_cursor_blinking};
+use crate::vga::text_mod::cursor::{set_big_cursor};
 
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {

--- a/src/vga/mod.rs
+++ b/src/vga/mod.rs
@@ -1,2 +1,1 @@
 pub mod text_mod;
-

--- a/src/vga/text_mod/cursor.rs
+++ b/src/vga/text_mod/cursor.rs
@@ -1,87 +1,75 @@
+use super::out;
 use crate::x86::io::{inb, outb};
+
+macro_rules! active_screen_index {
+    () => {
+        out::current_screen_index()
+    };
+}
+
+macro_rules! active_cursor {
+    ($screen_index:expr) => {
+        out::SCREEN_CURSORS[$screen_index]
+    };
+}
+
+macro_rules! active_cursor_mut {
+    ($screen_index:expr) => {
+        &mut out::SCREEN_CURSORS[$screen_index]
+    };
+}
+
+macro_rules! active_used_lines {
+    ($screen_index:expr) => {
+        out::SCREEN_USED_LINES[$screen_index]
+    };
+}
 
 const VGA_CMD_PORT: u16 = 0x3D4;
 const VGA_DATA_PORT: u16 = 0x3D5;
 
-#[derive(Copy, Clone)]
-pub struct Cursor {
-    pub x: u16,
-    pub y: u16,
-}
+fn write_cursor_shape(start: u8, end: u8) {
+    unsafe {
+        outb(VGA_CMD_PORT, 0x0A);
+        let cursor_start = inb(VGA_DATA_PORT);
+        outb(VGA_DATA_PORT, (cursor_start & 0xE0) | (start & 0x1F));
 
-pub static mut CURSOR: Cursor = Cursor { x: 0, y: 0 };
+        outb(VGA_CMD_PORT, 0x0B);
+        let cursor_end = inb(VGA_DATA_PORT);
+        outb(VGA_DATA_PORT, (cursor_end & 0xE0) | (end & 0x1F));
+    }
+}
 
 #[allow(dead_code)]
 pub fn set_big_cursor() {
-    unsafe {
-        outb(VGA_CMD_PORT, 0x0A);
-        outb(VGA_DATA_PORT, 0x00);
-        outb(VGA_CMD_PORT, 0x0B);
-        outb(VGA_DATA_PORT, 0x0F);
-    }
+    write_cursor_shape(0x00, 0x0F);
 }
 
 #[allow(dead_code)]
 pub fn set_small_cursor() {
-    unsafe {
-        outb(VGA_CMD_PORT, 0x0A);
-        outb(VGA_DATA_PORT, 0x20);
-        outb(VGA_CMD_PORT, 0x0B);
-        outb(VGA_DATA_PORT, 0x07);
-    }
+    write_cursor_shape(0x0E, 0x0F);
 }
+
 #[allow(dead_code)]
 pub fn set_cursor_color(color: u8) {
-    unsafe {
-        outb(VGA_CMD_PORT, 0x0A);
-        let cursor_start = inb(VGA_DATA_PORT);
-        outb(VGA_DATA_PORT, cursor_start | color);
-    }
+    write_cursor_shape(color & 0x0F, 0x0F);
 }
+
+/*  Couldn't figure this one out. Also, not needed for now
 #[allow(dead_code)]
 pub fn set_cursor_blinking(blink: bool) {
-    unsafe {
-        outb(VGA_CMD_PORT, 0x0A);
-        let cursor_start = inb(VGA_DATA_PORT);
-        if blink {
-            // Bit 5 of register 0x0A disables the hardware cursor.
-            // Clear it to keep the default hardware blink visible.
-            outb(VGA_DATA_PORT, cursor_start & !0x20);
-        } else {
-            // Set bit 5 to hide the cursor when "blinking" is disabled.
-            outb(VGA_DATA_PORT, cursor_start | 0x20);
-        }
-    }
+    out::set_cursor_visible(out::current_screen_index(), blink);
 }
+
 #[allow(dead_code)]
 pub fn set_cursor_blinking_rate(rate: u8) {
-    unsafe {
-        outb(VGA_CMD_PORT, 0x0A);
-        let cursor_start = inb(VGA_DATA_PORT);
-        outb(VGA_DATA_PORT, (cursor_start & 0xF8) | (rate & 0x07));
-    }
-}
-#[allow(dead_code)]
+    write_cursor_shape(0x00, rate.min(0x0F));
+} */
+
 pub fn set_cursor_shape(start: u8, end: u8) {
-    unsafe {
-        outb(VGA_CMD_PORT, 0x0A);
-        outb(VGA_DATA_PORT, start);
-        outb(VGA_CMD_PORT, 0x0B);
-        outb(VGA_DATA_PORT, end);
-    }
+    write_cursor_shape(start, end);
 }
 
-#[allow(dead_code)]
-pub fn move_cursor(dx: i16, dy: i16) {
-    unsafe {
-        CURSOR.x = (CURSOR.x as i16 + dx).max(0) as u16;
-        CURSOR.y = (CURSOR.y as i16 + dy).max(0) as u16;
-
-        set_cursor(CURSOR.x, CURSOR.y);
-    }
-}
-
-#[allow(dead_code)]
 pub fn set_cursor(x: u16, y: u16) {
     let max_x = 79u16;
     let max_y = 24u16;
@@ -89,32 +77,6 @@ pub fn set_cursor(x: u16, y: u16) {
     let y = y.min(max_y);
     let position = (y * 80 + x) as u16;
     unsafe {
-        CURSOR.x = x;
-        CURSOR.y = y;
-        outb(VGA_CMD_PORT, 0x0E);
-        outb(VGA_DATA_PORT, (position >> 8) as u8);
-        outb(VGA_CMD_PORT, 0x0F);
-        outb(VGA_DATA_PORT, (position & 0xFF) as u8);
-    }
-}
-
-#[allow(dead_code)]
-pub fn set_cursor_x(x: u16) {
-    unsafe {
-        let position = (CURSOR.y * 80 + x) as u16;
-        CURSOR.x = x;
-        outb(VGA_CMD_PORT, 0x0E);
-        outb(VGA_DATA_PORT, (position >> 8) as u8);
-        outb(VGA_CMD_PORT, 0x0F);
-        outb(VGA_DATA_PORT, (position & 0xFF) as u8);
-    }
-}
-
-#[allow(dead_code)]
-pub fn set_cursor_y(y: u16) {
-    unsafe {
-        let position = (y * 80 + CURSOR.x) as u16;
-        CURSOR.y = y;
         outb(VGA_CMD_PORT, 0x0E);
         outb(VGA_DATA_PORT, (position >> 8) as u8);
         outb(VGA_CMD_PORT, 0x0F);
@@ -137,5 +99,85 @@ pub fn enable_cursor() {
         outb(VGA_CMD_PORT, 0x0A);
         let cursor_start = inb(VGA_DATA_PORT);
         outb(VGA_DATA_PORT, cursor_start & !0x20);
+    }
+}
+
+fn move_to(x: usize, y: usize) {
+    let screen_index = active_screen_index!();
+    unsafe {
+        let cursor = active_cursor_mut!(screen_index);
+        cursor.x = x.min(out::VGA_WIDTH - 1) as u16;
+        cursor.y = y.min(out::SCROLLBACK_LINES - 1) as u16;
+        let cursor_line = usize::from(cursor.y);
+        if cursor_line + 1 > active_used_lines!(screen_index) {
+            active_used_lines!(screen_index) = cursor_line + 1;
+        }
+        out::sync_screen_state(screen_index);
+    }
+
+    out::render_screen(screen_index);
+}
+
+pub(super) fn move_left() {
+    let screen_index = active_screen_index!();
+    unsafe {
+        if active_cursor!(screen_index).x > 0 {
+            let cursor = active_cursor!(screen_index);
+            move_to(usize::from(cursor.x - 1), usize::from(cursor.y));
+        }
+    }
+}
+
+pub(super) fn move_right() {
+    let screen_index = active_screen_index!();
+    unsafe {
+        if usize::from(active_cursor!(screen_index).x) + 1 < out::VGA_WIDTH {
+            let cursor = active_cursor!(screen_index);
+            move_to(usize::from(cursor.x + 1), usize::from(cursor.y));
+        }
+    }
+}
+
+pub(super) fn move_up() {
+    let screen_index = active_screen_index!();
+    unsafe {
+        if active_cursor!(screen_index).y > 0 {
+            let cursor = active_cursor!(screen_index);
+            move_to(usize::from(cursor.x), usize::from(cursor.y - 1));
+        }
+    }
+}
+
+pub(super) fn move_down() {
+    let screen_index = active_screen_index!();
+    unsafe {
+        if usize::from(active_cursor!(screen_index).y) + 1 < active_used_lines!(screen_index) {
+            let cursor = active_cursor!(screen_index);
+            move_to(usize::from(cursor.x), usize::from(cursor.y + 1));
+        }
+    }
+}
+
+pub(super) fn sync_hardware_cursor(screen_index: usize) {
+    unsafe {
+        if !out::cursor_visible(screen_index) {
+            disable_cursor();
+            return;
+        }
+
+        let top_line = out::visible_top_line(screen_index);
+        let cursor = active_cursor!(screen_index);
+        let cursor_x = usize::from(cursor.x);
+        let cursor_y = usize::from(cursor.y);
+
+        if cursor_y >= top_line && cursor_y < top_line + out::VGA_HEIGHT {
+            enable_cursor();
+            set_cursor(
+                cursor_x.min(out::VGA_WIDTH - 1) as u16,
+                (cursor_y - top_line) as u16,
+            );
+        } else {
+            disable_cursor();
+        }
     }
 }

--- a/src/vga/text_mod/out.rs
+++ b/src/vga/text_mod/out.rs
@@ -1,13 +1,18 @@
-use super::cursor::{disable_cursor, enable_cursor, set_cursor};
+use super::cursor;
 
 pub const VGA_BUFFER: *mut u16 = 0xB8000 as *mut u16;
 pub const VGA_WIDTH: usize = 80;
 pub const VGA_HEIGHT: usize = 25;
 const VGA_SIZE: usize = VGA_WIDTH * VGA_HEIGHT;
 const VIRTUAL_SCREENS: usize = 6;
-const SCROLLBACK_LINES: usize = 200;
+pub(super) const SCROLLBACK_LINES: usize = 200;
 
-#[allow(dead_code)]
+#[derive(Copy, Clone)]
+pub(super) struct ScreenCursor {
+    pub x: u16,
+    pub y: u16,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Color {
@@ -39,24 +44,25 @@ impl ColorCode {
     }
 }
 
-pub static mut CURRENT_COLOR: ColorCode = ColorCode::new(Color::White, Color::Black);
-static mut SCREEN_BUFFERS: [[u16; VGA_SIZE * SCROLLBACK_LINES]; VIRTUAL_SCREENS] =
+pub(super) static mut CURRENT_COLOR: ColorCode = ColorCode::new(Color::White, Color::Black);
+pub(super) static mut SCREEN_BUFFERS: [[u16; VGA_SIZE * SCROLLBACK_LINES]; VIRTUAL_SCREENS] =
     [[0; VGA_SIZE * SCROLLBACK_LINES]; VIRTUAL_SCREENS];
-static mut SCREEN_CURSORS: [super::cursor::Cursor; VIRTUAL_SCREENS] =
-    [super::cursor::Cursor { x: 0, y: 0 }; VIRTUAL_SCREENS];
-static mut SCREEN_USED_LINES: [usize; VIRTUAL_SCREENS] = [1; VIRTUAL_SCREENS];
-static mut SCREEN_VIEWPORTS: [usize; VIRTUAL_SCREENS] = [0; VIRTUAL_SCREENS];
+pub(super) static mut SCREEN_CURSORS: [ScreenCursor; VIRTUAL_SCREENS] =
+    [ScreenCursor { x: 0, y: 0 }; VIRTUAL_SCREENS];
+pub(super) static mut SCREEN_CURSOR_VISIBLE: [bool; VIRTUAL_SCREENS] = [true; VIRTUAL_SCREENS];
+pub(super) static mut SCREEN_USED_LINES: [usize; VIRTUAL_SCREENS] = [1; VIRTUAL_SCREENS];
+pub(super) static mut SCREEN_VIEWPORTS: [usize; VIRTUAL_SCREENS] = [0; VIRTUAL_SCREENS];
 static mut ACTIVE_SCREEN: usize = 0;
 
 fn blank_cell() -> u16 {
     unsafe { (b' ' as u16) | ((CURRENT_COLOR.0 as u16) << 8) }
 }
 
-fn cell_index(line: usize, column: usize) -> usize {
+pub(super) fn cell_index(line: usize, column: usize) -> usize {
     line * VGA_WIDTH + column
 }
 
-fn clear_buffer_line(screen_index: usize, line: usize) {
+pub(super) fn clear_buffer_line(screen_index: usize, line: usize) {
     let blank = blank_cell();
     unsafe {
         for column in 0..VGA_WIDTH {
@@ -65,7 +71,7 @@ fn clear_buffer_line(screen_index: usize, line: usize) {
     }
 }
 
-fn shift_buffer_up(screen_index: usize) {
+pub(super) fn shift_buffer_up(screen_index: usize) {
     unsafe {
         for line in 1..SCROLLBACK_LINES {
             for column in 0..VGA_WIDTH {
@@ -83,7 +89,7 @@ fn shift_buffer_up(screen_index: usize) {
     }
 }
 
-fn visible_top_line(screen_index: usize) -> usize {
+pub(super) fn visible_top_line(screen_index: usize) -> usize {
     unsafe {
         let used_lines = SCREEN_USED_LINES[screen_index].min(SCROLLBACK_LINES);
         let max_scroll = used_lines.saturating_sub(VGA_HEIGHT);
@@ -92,7 +98,7 @@ fn visible_top_line(screen_index: usize) -> usize {
     }
 }
 
-fn render_screen(screen_index: usize) {
+pub(super) fn render_screen(screen_index: usize) {
     unsafe {
         let top_line = visible_top_line(screen_index);
         let used_lines = SCREEN_USED_LINES[screen_index].min(SCROLLBACK_LINES);
@@ -105,24 +111,36 @@ fn render_screen(screen_index: usize) {
                 } else {
                     blank_cell()
                 };
-                VGA_BUFFER.offset(cell_index(row, column) as isize)
+                VGA_BUFFER
+                    .offset(cell_index(row, column) as isize)
                     .write_volatile(value);
             }
         }
     }
 
-    update_hardware_cursor(screen_index);
+    cursor::sync_hardware_cursor(screen_index);
 }
 
-fn current_screen_index() -> usize {
+// pub(super) fn set_cursor_visible(screen_index: usize, visible: bool) {
+//     unsafe {
+//         SCREEN_CURSOR_VISIBLE[screen_index] = visible;
+//     }
+//     render_screen(screen_index);
+// }
+
+pub(super) fn cursor_visible(screen_index: usize) -> bool {
+    unsafe { SCREEN_CURSOR_VISIBLE[screen_index] }
+}
+
+pub(super) fn current_screen_index() -> usize {
     unsafe { ACTIVE_SCREEN }
 }
 
-fn current_cursor() -> super::cursor::Cursor {
+pub(super) fn current_cursor() -> ScreenCursor {
     unsafe { SCREEN_CURSORS[ACTIVE_SCREEN] }
 }
 
-fn sync_screen_state(screen_index: usize) {
+pub(super) fn sync_screen_state(screen_index: usize) {
     unsafe {
         SCREEN_USED_LINES[screen_index] = SCREEN_USED_LINES[screen_index].min(SCROLLBACK_LINES);
         SCREEN_VIEWPORTS[screen_index] = SCREEN_VIEWPORTS[screen_index]
@@ -130,110 +148,9 @@ fn sync_screen_state(screen_index: usize) {
     }
 }
 
-fn newline_with_scroll() {
-    let screen_index = current_screen_index();
-    unsafe {
-        let cursor = &mut SCREEN_CURSORS[screen_index];
-        cursor.x = 0;
-
-        let next_line = usize::from(cursor.y) + 1;
-        if next_line >= SCROLLBACK_LINES {
-            shift_buffer_up(screen_index);
-            cursor.y = (SCROLLBACK_LINES - 1) as u16;
-        } else {
-            cursor.y = next_line as u16;
-        }
-
-        let cursor_line = usize::from(cursor.y);
-        if cursor_line + 1 > SCREEN_USED_LINES[screen_index] {
-            SCREEN_USED_LINES[screen_index] = cursor_line + 1;
-            clear_buffer_line(screen_index, cursor_line);
-        }
-
-        sync_screen_state(screen_index);
-    }
-
-    render_screen(screen_index);
-}
-
-fn backspace() {
-    let screen_index = current_screen_index();
-    unsafe {
-        let cursor = &mut SCREEN_CURSORS[screen_index];
-        if cursor.x > 0 {
-            cursor.x -= 1;
-        } else if cursor.y > 0 {
-            cursor.y -= 1;
-            cursor.x = (VGA_WIDTH - 1) as u16;
-        } else {
-            return;
-        }
-
-        let index = cell_index(usize::from(cursor.y), usize::from(cursor.x));
-        SCREEN_BUFFERS[screen_index][index] = blank_cell();
-        sync_screen_state(screen_index);
-    }
-
-    render_screen(screen_index);
-}
-
-fn move_cursor_to(x: usize, y: usize) {
-    let screen_index = current_screen_index();
-    unsafe {
-        let cursor = &mut SCREEN_CURSORS[screen_index];
-        cursor.x = x.min(VGA_WIDTH - 1) as u16;
-        cursor.y = y.min(SCROLLBACK_LINES - 1) as u16;
-        let cursor_line = usize::from(cursor.y);
-        if cursor_line + 1 > SCREEN_USED_LINES[screen_index] {
-            SCREEN_USED_LINES[screen_index] = cursor_line + 1;
-        }
-        sync_screen_state(screen_index);
-    }
-
-    render_screen(screen_index);
-}
-
-fn write_cell(screen_index: usize, line: usize, column: usize, value: u16) {
+pub(super) fn write_cell(screen_index: usize, line: usize, column: usize, value: u16) {
     unsafe {
         SCREEN_BUFFERS[screen_index][cell_index(line, column)] = value;
-    }
-}
-
-fn write_byte(byte: u8) {
-    let screen_index = current_screen_index();
-
-    match byte {
-        b'\n' => newline_with_scroll(),
-        b'\r' => unsafe {
-            SCREEN_CURSORS[screen_index].x = 0;
-            render_screen(screen_index);
-        },
-        0x08 => backspace(),
-        b'\t' => {
-            for _ in 0..4 {
-                write_byte(b' ');
-            }
-        }
-        byte => {
-            let cursor = current_cursor();
-            let vga_char = (byte as u16) | ((unsafe { CURRENT_COLOR.0 } as u16) << 8);
-            write_cell(
-                screen_index,
-                usize::from(cursor.y),
-                usize::from(cursor.x),
-                vga_char,
-            );
-
-            unsafe {
-                SCREEN_CURSORS[screen_index].x = SCREEN_CURSORS[screen_index].x.saturating_add(1);
-                if usize::from(SCREEN_CURSORS[screen_index].x) >= VGA_WIDTH {
-                    newline_with_scroll();
-                } else {
-                    sync_screen_state(screen_index);
-                    render_screen(screen_index);
-                }
-            }
-        }
     }
 }
 
@@ -251,81 +168,43 @@ pub fn clear() {
         for line in 0..SCROLLBACK_LINES {
             clear_buffer_line(screen_index, line);
         }
-        SCREEN_CURSORS[screen_index] = super::cursor::Cursor { x: 0, y: 0 };
+        SCREEN_CURSORS[screen_index] = ScreenCursor { x: 0, y: 0 };
+        SCREEN_CURSOR_VISIBLE[screen_index] = true;
         SCREEN_USED_LINES[screen_index] = 1;
         SCREEN_VIEWPORTS[screen_index] = 0;
     }
     render_screen(screen_index);
 }
 
-#[allow(dead_code)]
 pub fn print(str: &str) {
-    for &byte in str.as_bytes() {
-        write_byte(byte);
-    }
+    super::print::write_str(str);
 }
 
-#[allow(dead_code)]
 pub fn print_char(c: char) {
-    let byte = if (c as u32) <= 0xFF { c as u8 } else { b'?' };
-    write_byte(byte);
+    super::print::write_char(c);
 }
 
-#[allow(dead_code)]
+// #[allow(dead_code)]
 pub fn newline() {
-    newline_with_scroll();
+    super::print::newline();
 }
 
-#[allow(dead_code)]
-pub fn scroll() {
-    newline_with_scroll();
-}
-
-#[allow(dead_code)]
 pub fn move_cursor_left() {
-    let screen_index = current_screen_index();
-    unsafe {
-        if SCREEN_CURSORS[screen_index].x > 0 {
-            let cursor = SCREEN_CURSORS[screen_index];
-            move_cursor_to(usize::from(cursor.x - 1), usize::from(cursor.y));
-        }
-    }
+    cursor::move_left();
 }
 
-#[allow(dead_code)]
 pub fn move_cursor_right() {
-    let screen_index = current_screen_index();
-    unsafe {
-        if usize::from(SCREEN_CURSORS[screen_index].x) + 1 < VGA_WIDTH {
-            let cursor = SCREEN_CURSORS[screen_index];
-            move_cursor_to(usize::from(cursor.x + 1), usize::from(cursor.y));
-        }
-    }
+    cursor::move_right();
 }
 
-#[allow(dead_code)]
 pub fn move_cursor_up() {
-    let screen_index = current_screen_index();
-    unsafe {
-        if SCREEN_CURSORS[screen_index].y > 0 {
-            let cursor = SCREEN_CURSORS[screen_index];
-            move_cursor_to(usize::from(cursor.x), usize::from(cursor.y - 1));
-        }
-    }
+    cursor::move_up();
 }
 
-#[allow(dead_code)]
 pub fn move_cursor_down() {
-    let screen_index = current_screen_index();
-    unsafe {
-        if usize::from(SCREEN_CURSORS[screen_index].y) + 1 < SCREEN_USED_LINES[screen_index] {
-            let cursor = SCREEN_CURSORS[screen_index];
-            move_cursor_to(usize::from(cursor.x), usize::from(cursor.y + 1));
-        }
-    }
+    cursor::move_down();
 }
 
-#[allow(dead_code)]
 pub fn scroll_view_up() {
     let screen_index = current_screen_index();
     unsafe {
@@ -337,7 +216,6 @@ pub fn scroll_view_up() {
     render_screen(screen_index);
 }
 
-#[allow(dead_code)]
 pub fn scroll_view_down() {
     let screen_index = current_screen_index();
     unsafe {
@@ -348,30 +226,14 @@ pub fn scroll_view_down() {
     render_screen(screen_index);
 }
 
-fn update_hardware_cursor(screen_index: usize) {
-    unsafe {
-        let top_line = visible_top_line(screen_index);
-        let cursor = SCREEN_CURSORS[screen_index];
-        let cursor_x = usize::from(cursor.x);
-        let cursor_y = usize::from(cursor.y);
-
-        if cursor_y >= top_line && cursor_y < top_line + VGA_HEIGHT {
-            enable_cursor();
-            set_cursor(cursor_x.min(VGA_WIDTH - 1) as u16, (cursor_y - top_line) as u16);
-        } else {
-            disable_cursor();
-        }
-    }
-}
-
-#[allow(dead_code)]
 pub fn init_virtual_screens() {
     unsafe {
         for screen_index in 0..VIRTUAL_SCREENS {
             for line in 0..SCROLLBACK_LINES {
                 clear_buffer_line(screen_index, line);
             }
-            SCREEN_CURSORS[screen_index] = super::cursor::Cursor { x: 0, y: 0 };
+            SCREEN_CURSORS[screen_index] = ScreenCursor { x: 0, y: 0 };
+            SCREEN_CURSOR_VISIBLE[screen_index] = true;
             SCREEN_USED_LINES[screen_index] = 1;
             SCREEN_VIEWPORTS[screen_index] = 0;
         }
@@ -386,7 +248,6 @@ pub fn active_screen() -> usize {
     unsafe { ACTIVE_SCREEN }
 }
 
-#[allow(dead_code)]
 pub fn switch_screen(screen_index: usize) {
     if screen_index >= VIRTUAL_SCREENS {
         return;

--- a/src/vga/text_mod/print.rs
+++ b/src/vga/text_mod/print.rs
@@ -6,3 +6,110 @@ macro_rules! print {
     });
 }
 
+use super::out;
+
+fn blank_cell() -> u16 {
+    unsafe { (b' ' as u16) | ((out::CURRENT_COLOR.0 as u16) << 8) }
+}
+
+fn newline_with_scroll() {
+    let screen_index = out::current_screen_index();
+    unsafe {
+        let cursor = &mut out::SCREEN_CURSORS[screen_index];
+        cursor.x = 0;
+
+        let next_line = usize::from(cursor.y) + 1;
+        if next_line >= out::SCROLLBACK_LINES {
+            out::shift_buffer_up(screen_index);
+            cursor.y = (out::SCROLLBACK_LINES - 1) as u16;
+        } else {
+            cursor.y = next_line as u16;
+        }
+
+        let cursor_line = usize::from(cursor.y);
+        if cursor_line + 1 > out::SCREEN_USED_LINES[screen_index] {
+            out::SCREEN_USED_LINES[screen_index] = cursor_line + 1;
+            out::clear_buffer_line(screen_index, cursor_line);
+        }
+
+        out::sync_screen_state(screen_index);
+    }
+
+    out::render_screen(screen_index);
+}
+
+fn backspace() {
+    let screen_index = out::current_screen_index();
+    unsafe {
+        let cursor = &mut out::SCREEN_CURSORS[screen_index];
+        if cursor.x > 0 {
+            cursor.x -= 1;
+        } else if cursor.y > 0 {
+            cursor.y -= 1;
+            cursor.x = (out::VGA_WIDTH - 1) as u16;
+        } else {
+            return;
+        }
+
+        let index = out::cell_index(usize::from(cursor.y), usize::from(cursor.x));
+        out::SCREEN_BUFFERS[screen_index][index] = blank_cell();
+        out::sync_screen_state(screen_index);
+    }
+
+    out::render_screen(screen_index);
+}
+
+fn write_byte(byte: u8) {
+    let screen_index = out::current_screen_index();
+
+    match byte {
+        b'\n' => newline_with_scroll(),
+        b'\r' => unsafe {
+            out::SCREEN_CURSORS[screen_index].x = 0;
+            out::render_screen(screen_index);
+        },
+        0x08 => backspace(),
+        b'\t' => {
+            for _ in 0..4 {
+                write_byte(b' ');
+            }
+        }
+        byte => {
+            let cursor = out::current_cursor();
+            let vga_char = (byte as u16) | ((unsafe { out::CURRENT_COLOR.0 } as u16) << 8);
+            out::write_cell(
+                screen_index,
+                usize::from(cursor.y),
+                usize::from(cursor.x),
+                vga_char,
+            );
+
+            unsafe {
+                out::SCREEN_CURSORS[screen_index].x =
+                    out::SCREEN_CURSORS[screen_index].x.saturating_add(1);
+                if usize::from(out::SCREEN_CURSORS[screen_index].x) >= out::VGA_WIDTH {
+                    newline_with_scroll();
+                } else {
+                    out::sync_screen_state(screen_index);
+                    out::render_screen(screen_index);
+                }
+            }
+        }
+    }
+}
+
+pub fn write_str(text: &str) {
+    for &byte in text.as_bytes() {
+        write_byte(byte);
+    }
+}
+
+pub fn write_char(c: char) {
+    let byte = if (c as u32) <= 0xFF { c as u8 } else { b'?' };
+    write_byte(byte);
+}
+
+pub fn newline() {
+    newline_with_scroll();
+}
+


### PR DESCRIPTION
refactored cursor operations:
 - fixed small cursor
 - commented out blinking toggle, neither works or needed
 - overall changes

moved cursor handling operations to `src/text_mod/cursor.rs`
moved printing operations to `src/text_mod/print.rs`